### PR TITLE
Use nostr.json

### DIFF
--- a/nostr-verify.php
+++ b/nostr-verify.php
@@ -102,7 +102,7 @@ function render_nostr_document( $wp ) {
 	// check if it is a nostr request or not.
 	if (
 		! array_key_exists( 'well-known', $wp->query_vars )
-		|| 'nostr' !== $wp->query_vars['well-known']
+		|| 'nostr.json' !== $wp->query_vars['well-known']
 	) {
 		return;
 	}


### PR DESCRIPTION
Per spec at https://github.com/nostr-protocol/nips/blob/master/05.md

When testing this with the coracle.social client, it would not verify as it saw `not found` at https://kraft.blog/.well-known/nostr.json

This update allowed it to work for me.

An alternative, if clients aren't consistent, may be to check if `str_starts_with('nostr')` instead?